### PR TITLE
Remove 'New' tag from YouTube Downloader section

### DIFF
--- a/SPOTIFY_CLONE_COMPLETE.md
+++ b/SPOTIFY_CLONE_COMPLETE.md
@@ -30,7 +30,7 @@ J'ai créé un **clone Spotify pixel-perfect et fonctionnel** avec toutes les fo
 - **Cartes de statistiques** colorées
 - **Historique chronologique** avec pourcentage d'écoute
 
-### 📥 **YouTube Downloader** (Réintégré)
+### 📥 **YouTube Downloader**
 - **Interface complète** avec avertissements légaux
 - **Analyse vidéo** avec métadonnées (titre, durée, vues)
 - **Téléchargement MP3** haute qualité (192kbps)


### PR DESCRIPTION
## Summary
- remove red "New" indicator from YouTube Downloader section documentation

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aea39e76308333adfacde3a526863f