### PR TITLE
feat: add youtube downloader interface

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,7 @@ import Playlists from "./components/Playlists";
 import History from "./components/History";
 import LibraryView from "./components/LibraryView";
 import Player from "./components/Player";
+import YouTubeDownloader from "./components/YouTubeDownloader";
 
 function App() {
   const [currentView, setCurrentView] = useState('home');
@@ -114,13 +115,16 @@ function App() {
       
       case 'library':
         return <LibraryView />;
-      
+
       case 'playlists':
         return <Playlists />;
-      
+
       case 'history':
         return <History />;
-      
+
+      case 'downloader':
+        return <YouTubeDownloader />;
+
       default:
         return (
           <div className="p-8 text-center text-gray-400">

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -10,6 +10,7 @@ const Navigation = ({ currentView, onViewChange }) => {
     { id: 'home', icon: Home, label: 'Accueil' },
     { id: 'search', icon: SearchIcon, label: 'Rechercher' },
     { id: 'library', icon: Library, label: 'Votre bibliothèque' },
+    { id: 'downloader', icon: Download, label: 'Téléchargeur' },
   ];
 
   const libraryItems = [

--- a/frontend/src/components/YouTubeDownloader.jsx
+++ b/frontend/src/components/YouTubeDownloader.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { Input } from './ui/input';
+import { Button } from './ui/button';
+
+const YouTubeDownloader = () => {
+  const [url, setUrl] = useState('');
+  const [info, setInfo] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleAnalyze = async () => {
+    setLoading(true);
+    setError('');
+    setInfo(null);
+    try {
+      const res = await axios.post('/api/youtube/info', { url });
+      setInfo(res.data);
+    } catch (e) {
+      setError(e.response?.data?.detail || 'Analyse échouée');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDownload = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await axios.post(
+        '/api/youtube/download',
+        { url },
+        { responseType: 'blob' }
+      );
+      const blobUrl = window.URL.createObjectURL(res.data);
+      const a = document.createElement('a');
+      const filename = info?.title ? `${info.title}.mp3` : 'audio.mp3';
+      a.href = blobUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(blobUrl);
+    } catch (e) {
+      setError(e.response?.data?.detail || 'Téléchargement échoué');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-8 max-w-xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Téléchargeur YouTube</h1>
+      <div className="flex gap-2">
+        <Input
+          placeholder="URL YouTube"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          className="flex-1"
+        />
+        <Button onClick={handleAnalyze} disabled={!url || loading}>
+          Analyser
+        </Button>
+      </div>
+      {info && (
+        <div className="p-4 bg-gray-800 rounded">
+          <p className="font-medium">{info.title}</p>
+          {info.duration && (
+            <p className="text-sm text-gray-400">Durée: {info.duration}s</p>
+          )}
+        </div>
+      )}
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {info && (
+        <Button onClick={handleDownload} disabled={loading}>
+          {loading ? 'Téléchargement...' : 'Télécharger en MP3'}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default YouTubeDownloader;


### PR DESCRIPTION
## Summary
- add navigation entry for YouTube downloader
- implement YouTube downloader page to fetch info and download audio
- wire page into main app view switch

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aea5ad6a44833398f77c3aeef72cad