### PR TITLE
Make frontend responsive on mobile

### DIFF
--- a/frontend/src/SpotifyApp.jsx
+++ b/frontend/src/SpotifyApp.jsx
@@ -49,7 +49,7 @@ const SpotifyApp = () => {
   // Main Discover View
   return (
     <div className="h-screen bg-black flex flex-col">
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-1 overflow-hidden flex-col md:flex-row">
         <div className="flex flex-col">
           <Sidebar />
           <div className="p-4 border-t border-gray-800 space-y-2">

--- a/frontend/src/components/MainContent.jsx
+++ b/frontend/src/components/MainContent.jsx
@@ -155,7 +155,7 @@ const MainContent = ({ onTrackSelect }) => {
         {/* Good afternoon section */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold mb-6">Good afternoon</h1>
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {['Liked Songs', 'Daily Mix 1', 'Discover Weekly', 'Release Radar', 'Chill Hits', 'Your Top Songs 2024'].map((playlist, index) => (
               <div key={index} className="bg-gray-800 rounded-md flex items-center overflow-hidden hover:bg-gray-700 transition-colors cursor-pointer group">
                 <div className="w-16 h-16 bg-gradient-to-br from-purple-500 to-blue-500 flex items-center justify-center">

--- a/frontend/src/components/MusicPlayer.jsx
+++ b/frontend/src/components/MusicPlayer.jsx
@@ -18,9 +18,9 @@ const MusicPlayer = ({ currentTrack }) => {
   };
 
   return (
-    <div className="h-24 bg-gray-900 border-t border-gray-800 flex items-center justify-between px-4">
+    <div className="bg-gray-900 border-t border-gray-800 flex flex-col md:flex-row items-center justify-between px-4 py-2 md:h-24 gap-2">
       {/* Current Track Info */}
-      <div className="flex items-center gap-4 w-80">
+      <div className="flex items-center gap-4 w-full md:w-80 mb-2 md:mb-0">
         {currentTrack && (
           <>
             <img 
@@ -49,7 +49,7 @@ const MusicPlayer = ({ currentTrack }) => {
       </div>
 
       {/* Player Controls */}
-      <div className="flex flex-col items-center gap-2 flex-1 max-w-2xl">
+      <div className="flex flex-col items-center gap-2 w-full flex-1 md:max-w-2xl">
         <div className="flex items-center gap-4">
           <Button
             variant="ghost"
@@ -103,7 +103,7 @@ const MusicPlayer = ({ currentTrack }) => {
       </div>
 
       {/* Volume & Additional Controls */}
-      <div className="flex items-center gap-2 w-80 justify-end">
+      <div className="flex items-center gap-2 w-full md:w-80 justify-end mt-2 md:mt-0">
         <Button variant="ghost" size="sm" className="p-2 text-gray-400 hover:text-white">
           <PictureInPicture2 size={16} />
         </Button>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -20,7 +20,7 @@ const Sidebar = () => {
   ];
 
   return (
-    <div className="w-64 h-full bg-black text-white flex flex-col">
+    <div className="w-full md:w-64 h-full bg-black text-white flex flex-col">
       {/* Logo */}
       <div className="p-6">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- adjust layout to stack sidebar and content on small screens
- expand sidebar and player widths for narrow viewports
- support responsive card grids for mobile users

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeab5a5ff483338f71f7c497aa6b9f