### PR TITLE
feat: support mp3 conversion for any video link

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -68,11 +68,11 @@ class StatusCheckCreate(BaseModel):
     client_name: str
 
 
-class YouTubeInfoRequest(BaseModel):
+class VideoInfoRequest(BaseModel):
     url: str
 
 
-class YouTubeDownloadRequest(BaseModel):
+class VideoDownloadRequest(BaseModel):
     url: str
     format: str = "mp3"
 
@@ -96,9 +96,9 @@ async def get_status_checks():
     return [StatusCheck(**s) for s in status_checks]
 
 
-@api_router.post("/youtube/info")
-async def youtube_info(input: YouTubeInfoRequest):
-    """Return info about a YouTube video with better reliability."""
+@api_router.post("/video/info")
+async def video_info(input: VideoInfoRequest):
+    """Return information about a video from various platforms."""
     headers = {
         "User-Agent": (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
@@ -112,8 +112,6 @@ async def youtube_info(input: YouTubeInfoRequest):
         "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
         "Keep-Alive": "300",
         "Connection": "keep-alive",
-        "X-YouTube-Client-Name": "1",
-        "X-YouTube-Client-Version": "2.20240101.00.00",
     }
     opts = {
         "quiet": True,
@@ -137,8 +135,8 @@ async def youtube_info(input: YouTubeInfoRequest):
     return {"title": info.get("title"), "duration": info.get("duration")}
 
 
-@api_router.post("/youtube/download")
-async def youtube_download(input: YouTubeDownloadRequest):
+@api_router.post("/video/download")
+async def video_download(input: VideoDownloadRequest):
     headers = {
         "User-Agent": (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
@@ -152,8 +150,6 @@ async def youtube_download(input: YouTubeDownloadRequest):
         "Accept-Charset": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
         "Keep-Alive": "300",
         "Connection": "keep-alive",
-        "X-YouTube-Client-Name": "1",
-        "X-YouTube-Client-Version": "2.20240101.00.00",
     }
     base_opts = {
         "outtmpl": str(DOWNLOAD_DIR / "%(id)s.%(ext)s"),
@@ -161,10 +157,8 @@ async def youtube_download(input: YouTubeDownloadRequest):
         "no_warnings": True,
         "http_headers": headers,
         "geo_bypass": True,
-        "geo_bypass_country": "US",
         "age_limit": None,
         "no_check_certificate": True,
-        "youtube_include_dash_manifest": False,
         "skip_unavailable_fragments": True,
         "keep_fragments": False,
         "abort_on_unavailable_fragment": False,
@@ -206,7 +200,7 @@ async def youtube_download(input: YouTubeDownloadRequest):
     if info is None:
         error_msg = str(last_error)
         if "403" in error_msg or "Forbidden" in error_msg:
-            detail = "YouTube a temporairement bloqué cette requête..."
+            detail = "La plateforme vidéo a temporairement bloqué cette requête..."
         elif "404" in error_msg or "not available" in error_msg:
             detail = "Cette vidéo n'est pas disponible ou a été supprimée."
         elif "private" in error_msg.lower():

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,7 +15,7 @@ import Playlists from "./components/Playlists";
 import History from "./components/History";
 import LibraryView from "./components/LibraryView";
 import Player from "./components/Player";
-import YouTubeDownloader from "./components/YouTubeDownloader";
+import VideoDownloader from "./components/VideoDownloader";
 
 function App() {
   const [currentView, setCurrentView] = useState('home');
@@ -123,7 +123,7 @@ function App() {
         return <History />;
 
       case 'downloader':
-        return <YouTubeDownloader />;
+        return <VideoDownloader />;
 
       default:
         return (

--- a/frontend/src/components/VideoDownloader.jsx
+++ b/frontend/src/components/VideoDownloader.jsx
@@ -3,7 +3,7 @@ import axios from "axios";
 import { Input } from "./ui/input";
 import { Button } from "./ui/button";
 
-const YouTubeDownloader = () => {
+const VideoDownloader = () => {
   const [url, setUrl] = useState("");
   const [info, setInfo] = useState(null);
   const [error, setError] = useState("");
@@ -14,14 +14,14 @@ const YouTubeDownloader = () => {
     setError("");
     setInfo(null);
     try {
-      const res = await axios.post("/api/youtube/info", { url });
+      const res = await axios.post("/api/video/info", { url });
       setInfo(res.data);
     } catch (e) {
       let errorMessage = "Analyse échouée";
       if (e.response?.data?.detail) {
         errorMessage = e.response.data.detail;
       } else if (e.response?.status === 403) {
-        errorMessage = "YouTube a bloqué cette requête. Essayez plus tard.";
+        errorMessage = "La plateforme a bloqué cette requête. Essayez plus tard.";
       } else if (e.response?.status === 429) {
         errorMessage = "Trop de requêtes. Attendez quelques minutes.";
       }
@@ -36,7 +36,7 @@ const YouTubeDownloader = () => {
     setError("");
     try {
       const res = await axios.post(
-        "/api/youtube/download",
+        "/api/video/download",
         { url },
         { responseType: "blob" },
       );
@@ -54,7 +54,7 @@ const YouTubeDownloader = () => {
       if (e.response?.data?.detail) {
         errorMessage = e.response.data.detail;
       } else if (e.response?.status === 403) {
-        errorMessage = "YouTube a bloqué cette requête. Essayez plus tard.";
+        errorMessage = "La plateforme a bloqué cette requête. Essayez plus tard.";
       } else if (e.response?.status === 429) {
         errorMessage = "Trop de requêtes. Attendez quelques minutes.";
       }
@@ -66,10 +66,10 @@ const YouTubeDownloader = () => {
 
   return (
     <div className="p-8 max-w-xl mx-auto space-y-4">
-      <h1 className="text-2xl font-bold">Téléchargeur YouTube</h1>
+      <h1 className="text-2xl font-bold">Convertisseur Vidéo en MP3</h1>
       <div className="flex gap-2">
         <Input
-          placeholder="URL YouTube"
+          placeholder="URL de la vidéo (YouTube, Vimeo, etc.)"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
           className="flex-1"
@@ -85,7 +85,7 @@ const YouTubeDownloader = () => {
         <ul className="text-blue-200 space-y-1 text-xs">
           <li>• Utilisez des vidéos courtes (moins de 10 minutes)</li>
           <li>• Évitez les vidéos avec restrictions géographiques</li>
-          <li>• Les vidéos musicales populaires peuvent être bloquées</li>
+          <li>• Certaines vidéos populaires peuvent être bloquées</li>
           <li>• Essayez du contenu éducatif ou Creative Commons</li>
         </ul>
       </div>
@@ -107,4 +107,4 @@ const YouTubeDownloader = () => {
   );
 };
 
-export default YouTubeDownloader;
+export default VideoDownloader;


### PR DESCRIPTION
## Summary
- generalize backend endpoints to convert videos from multiple platforms to mp3
- rename frontend downloader to handle generic video URLs

## Testing
- `pytest`
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aedde085548333bc99c460fb7b1b8e