### PR TITLE
Remove video link analysis and download videos as MP3

### DIFF
--- a/SPOTIFY_CLONE_COMPLETE.md
+++ b/SPOTIFY_CLONE_COMPLETE.md
@@ -32,7 +32,6 @@ J'ai créé un **clone Spotify pixel-perfect et fonctionnel** avec toutes les fo
 
 ### 📥 **YouTube Downloader**
 - **Interface complète** avec avertissements légaux
-- **Analyse vidéo** avec métadonnées (titre, durée, vues)
 - **Téléchargement MP3** haute qualité (192kbps)
 - **Intégration bibliothèque** automatique
 - **Gestion des téléchargements** avec lecture directe
@@ -105,7 +104,6 @@ J'ai créé un **clone Spotify pixel-perfect et fonctionnel** avec toutes les fo
 
 ### **YouTube Downloader API**
 ```
-POST /api/youtube/info       - Analyser vidéo
 POST /api/youtube/download   - Télécharger MP3
 GET  /api/youtube/downloads  - Lister téléchargements
 GET  /api/youtube/download/{id}/stream - Streamer fichier
@@ -211,7 +209,7 @@ Lecture pistes → Tracking automatique → Statistiques → Recommandations
 
 ### **4. Extension YouTube**
 ```
-URL YouTube → Analyse vidéo → Téléchargement MP3 → Intégration bibliothèque
+URL YouTube → Téléchargement MP3 → Intégration bibliothèque
 ```
 
 ## 🎯 Résultat Final

--- a/YOUTUBE_DOWNLOADER_README.md
+++ b/YOUTUBE_DOWNLOADER_README.md
@@ -22,17 +22,15 @@ Cette fonctionnalité de téléchargement YouTube doit être utilisée conformé
 ### ✅ Ce qui est implémenté :
 
 1. **Interface intégrée** dans l'application Spotify clone
-2. **Extraction d'informations** vidéo YouTube (titre, artiste, durée, miniature)
-3. **Téléchargement audio** en MP3 haute qualité (192kbps)
-4. **Gestion des téléchargements** avec base de données MongoDB
-5. **Interface utilisateur** intuitive avec notifications
-6. **Avertissements légaux** bien visibles
+2. **Téléchargement audio** en MP3 haute qualité (192kbps)
+3. **Gestion des téléchargements** avec base de données MongoDB
+4. **Interface utilisateur** intuitive avec notifications
+5. **Avertissements légaux** bien visibles
 
 ### 🔧 API Backend
 
 Les endpoints suivants sont disponibles :
 
-- `POST /api/youtube/info` - Obtenir les informations d'une vidéo
 - `POST /api/youtube/download` - Télécharger l'audio en MP3
 - `GET /api/youtube/downloads` - Liste des téléchargements
 - `GET /api/youtube/download/{id}/stream` - Streamer un fichier téléchargé
@@ -48,9 +46,7 @@ Les endpoints suivants sont disponibles :
 ### 2. Télécharger une vidéo
 1. Copiez l'URL YouTube de la vidéo (ex: `https://www.youtube.com/watch?v=dQw4w9WgXcQ`)
 2. Collez l'URL dans le champ de saisie
-3. Cliquez sur "Analyser" pour récupérer les informations
-4. Vérifiez les informations affichées (titre, artiste, durée)
-5. Cliquez sur "Télécharger en MP3" pour lancer le téléchargement
+3. Cliquez sur "Télécharger en MP3" pour lancer le téléchargement
 
 ### 3. Gérer vos téléchargements
 - Tous les téléchargements apparaissent dans la section "Téléchargements"


### PR DESCRIPTION
## Summary
- Remove video info endpoint and simplify downloader to always return MP3
- Drop analyzer UI and trigger direct MP3 download from pasted URL
- Update documentation for new direct download flow

## Testing
- `pytest`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aef20696f0833394bcfe8b39a9a457