### PR TITLE
Handle JSON error responses in video downloader

### DIFF
--- a/frontend/src/components/VideoDownloader.jsx
+++ b/frontend/src/components/VideoDownloader.jsx
@@ -33,12 +33,22 @@ const VideoDownloader = () => {
       window.URL.revokeObjectURL(blobUrl);
     } catch (e) {
       let errorMessage = "Téléchargement échoué";
-      if (e.response?.data?.detail) {
-        errorMessage = e.response.data.detail;
-      } else if (e.response?.status === 403) {
-        errorMessage = "La plateforme a bloqué cette requête. Essayez plus tard.";
-      } else if (e.response?.status === 429) {
-        errorMessage = "Trop de requêtes. Attendez quelques minutes.";
+      const resp = e.response;
+      if (resp?.data) {
+        try {
+          const text = await resp.data.text();
+          const parsed = JSON.parse(text);
+          if (parsed.detail) errorMessage = parsed.detail;
+        } catch (_err) {
+          // ignore JSON parse errors, fall back to status-based messages
+        }
+      }
+      if (errorMessage === "Téléchargement échoué") {
+        if (resp?.status === 403) {
+          errorMessage = "La plateforme a bloqué cette requête. Essayez plus tard.";
+        } else if (resp?.status === 429) {
+          errorMessage = "Trop de requêtes. Attendez quelques minutes.";
+        }
       }
       setError(errorMessage);
     } finally {


### PR DESCRIPTION
## Summary
- Decode JSON error blobs returned by backend so user sees specific failure reasons instead of generic "Téléchargement échoué"

## Testing
- `pip install -r backend/requirements.txt` (fails: ProxyError 403 fetching imageio-ffmpeg)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af2e3ff48c8333adf6f54d06094ae5