### PR TITLE
Align YouTube download endpoint

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -94,7 +94,7 @@ async def get_status_checks():
     return [StatusCheck(**s) for s in status_checks]
 
 
-@api_router.post("/video/download")
+@api_router.post("/youtube/download")
 async def video_download(input: VideoDownloadRequest):
     headers = {
         "User-Agent": (

--- a/frontend/src/components/VideoDownloader.jsx
+++ b/frontend/src/components/VideoDownloader.jsx
@@ -13,7 +13,7 @@ const VideoDownloader = () => {
     setError("");
     try {
       const res = await axios.post(
-        "/api/video/download",
+        "/api/youtube/download",
         { url },
         { responseType: "blob" },
       );


### PR DESCRIPTION
## Summary
- switch backend download route to `/api/youtube/download`
- update frontend VideoDownloader to call the new YouTube endpoint

## Testing
- `pytest`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68afe6a40c5483338ac24dab3b794140