### PR TITLE
feat: allow optional yt-dlp proxy

### DIFF
--- a/YOUTUBE_DOWNLOADER_README.md
+++ b/YOUTUBE_DOWNLOADER_README.md
@@ -70,6 +70,9 @@ Les endpoints suivants sont disponibles :
 - Fichiers audio : `/tmp/music_downloads/`
 - Métadonnées : Base de données MongoDB
 
+### Variables d'environnement :
+- `YT_DLP_PROXY` : URL du proxy HTTP à utiliser par `yt-dlp` (optionnel)
+
 ## 🛡️ Sécurité et limitations
 
 1. **Validation d'URL** : Seules les URLs YouTube valides sont acceptées

--- a/backend/server.py
+++ b/backend/server.py
@@ -128,9 +128,10 @@ async def video_download(input: VideoDownloadRequest):
         "youtube_include_dash_manifest": False,
         "noplaylist": True,
         "ffmpeg_location": str(Path(FFMPEG_BINARY).parent),
-        # Disable environment proxies by default to avoid corporate proxy blocks
-        "proxy": os.getenv("YT_DLP_PROXY", ""),
     }
+    yt_dlp_proxy = os.getenv("YT_DLP_PROXY")
+    if yt_dlp_proxy:
+        base_opts["proxy"] = yt_dlp_proxy
     max_attempts = 2
     info = None
     last_error = None


### PR DESCRIPTION
## Summary
- allow yt-dlp to use proxy when `YT_DLP_PROXY` is defined
- document `YT_DLP_PROXY` variable for YouTube downloader

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aff52353988333857ebce7259cfb00