### PR TITLE
Add MP3 extraction pipeline

### DIFF
--- a/app/audio_pipeline.py
+++ b/app/audio_pipeline.py
@@ -1,0 +1,63 @@
+# INSERT START: imports
+import glob
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from .db import AUDIO_DIR, get_audio_job, update_audio_job
+
+# INSERT END: imports
+
+# INSERT START: pipeline
+
+def process_audio_job(db_module, audio_id: str) -> None:
+    try:
+        job = get_audio_job(audio_id)
+        if not job:
+            return
+        update_audio_job(audio_id, status="running", progress=5)
+        source_url = job["source_url"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            source_tmpl = tmp / "source.%(ext)s"
+            dl_cmd = [
+                "yt-dlp",
+                "-f",
+                "bestaudio/best",
+                "-o",
+                str(source_tmpl),
+                source_url,
+            ]
+            subprocess.run(dl_cmd, check=True)
+            downloaded = glob.glob(str(tmp / "source.*"))
+            if not downloaded:
+                raise RuntimeError("Download failed")
+            source_file = Path(downloaded[0])
+            output_file = AUDIO_DIR / f"{audio_id}.mp3"
+            ff_cmd = [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(source_file),
+                "-vn",
+                "-ac",
+                "2",
+                "-ar",
+                "44100",
+                "-b:a",
+                "192k",
+                str(output_file),
+            ]
+            subprocess.run(ff_cmd, check=True)
+        update_audio_job(
+            audio_id,
+            status="done",
+            progress=100,
+            filepath_mp3=str(output_file),
+        )
+    except Exception as exc:  # pragma: no cover
+        update_audio_job(audio_id, status="error", message=str(exc))
+
+# INSERT END: pipeline
+

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+# INSERT START: imports
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+import uuid
+
+# INSERT END: imports
+
+# INSERT START: constants
+AUDIO_DIR = Path("public/audio")
+AUDIO_DIR.mkdir(parents=True, exist_ok=True)
+DB_PATH = Path("audio_jobs.db")
+_conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+_conn.row_factory = sqlite3.Row
+# INSERT END: constants
+
+# INSERT START: model
+class Audio:
+    def __init__(self, **data: Any) -> None:
+        self.id: str = data.get("id", str(uuid.uuid4()))
+        self.created_at: datetime = data.get("created_at", datetime.utcnow())
+        self.source_url: str = data["source_url"]
+        self.status: str = data.get("status", "queued")
+        self.progress: int = data.get("progress", 0)
+        self.message: str = data.get("message", "")
+        self.title: Optional[str] = data.get("title")
+        self.duration_s: Optional[float] = data.get("duration_s")
+        self.filepath_mp3: Optional[str] = data.get("filepath_mp3")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "created_at": self.created_at.isoformat(),
+            "source_url": self.source_url,
+            "status": self.status,
+            "progress": self.progress,
+            "message": self.message,
+            "title": self.title,
+            "duration_s": self.duration_s,
+            "filepath_mp3": self.filepath_mp3,
+        }
+
+# INSERT END: model
+
+# INSERT START: init_db
+
+def init_db() -> None:
+    _conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS audio (
+            id TEXT PRIMARY KEY,
+            created_at TEXT,
+            source_url TEXT,
+            status TEXT,
+            progress INTEGER,
+            message TEXT,
+            title TEXT,
+            duration_s REAL,
+            filepath_mp3 TEXT
+        )
+        """
+    )
+    _conn.commit()
+
+# INSERT END: init_db
+
+# INSERT START: CRUD
+
+def create_audio_job(source_url: str) -> str:
+    audio = Audio(source_url=source_url)
+    _conn.execute(
+        """
+        INSERT INTO audio (
+            id, created_at, source_url, status, progress, message, title, duration_s, filepath_mp3
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            audio.id,
+            audio.created_at.isoformat(),
+            audio.source_url,
+            audio.status,
+            audio.progress,
+            audio.message,
+            audio.title,
+            audio.duration_s,
+            audio.filepath_mp3,
+        ),
+    )
+    _conn.commit()
+    return audio.id
+
+def update_audio_job(audio_id: str, **fields: Any) -> None:
+    if not fields:
+        return
+    cols = ", ".join(f"{k}=?" for k in fields.keys())
+    values = list(fields.values())
+    values.append(audio_id)
+    _conn.execute(f"UPDATE audio SET {cols} WHERE id=?", values)
+    _conn.commit()
+
+def get_audio_job(audio_id: str) -> Optional[Dict[str, Any]]:
+    cur = _conn.execute("SELECT * FROM audio WHERE id=?", (audio_id,))
+    row = cur.fetchone()
+    if row:
+        data = dict(row)
+        data["created_at"] = datetime.fromisoformat(data["created_at"])
+        return data
+    return None
+
+# INSERT END: CRUD
+
+# INSERT START: startup
+init_db()
+# INSERT END: startup
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,50 @@
+# INSERT START: imports
+from fastapi import BackgroundTasks, FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+from . import audio_pipeline
+from .db import AUDIO_DIR, create_audio_job, get_audio_job
+# INSERT END: imports
+
+# INSERT START: app
+app = FastAPI()
+# INSERT END: app
+
+# INSERT START: models
+class SubmitRequest(BaseModel):
+    url: str
+# INSERT END: models
+
+# INSERT START: endpoints
+@app.post("/audio/submit")
+def submit_audio(req: SubmitRequest, background_tasks: BackgroundTasks):
+    audio_id = create_audio_job(req.url)
+    background_tasks.add_task(audio_pipeline.process_audio_job, None, audio_id)
+    return {"audio_id": audio_id, "status": "queued"}
+
+
+@app.get("/audio/status/{audio_id}")
+def audio_status(audio_id: str):
+    job = get_audio_job(audio_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Audio job not found")
+    return {
+        "status": job["status"],
+        "progress": job["progress"],
+        "message": job["message"],
+        "title": job["title"],
+        "duration_s": job["duration_s"],
+        "filepath_mp3": job["filepath_mp3"],
+    }
+
+
+@app.get("/audio/download/{audio_id}")
+def audio_download(audio_id: str):
+    job = get_audio_job(audio_id)
+    if not job or not job.get("filepath_mp3"):
+        raise HTTPException(status_code=404, detail="File not ready")
+    return FileResponse(job["filepath_mp3"], media_type="audio/mpeg")
+
+# INSERT END: endpoints
+


### PR DESCRIPTION
## Summary
- add SQLite audio job model and CRUD helpers
- implement yt-dlp/ffmpeg pipeline for MP3 extraction
- expose FastAPI endpoints to submit, track, and download audio jobs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b02eed520c8333996225914e0dde88