### PR TITLE
Allow server start without Mongo env vars

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -24,9 +24,16 @@ load_dotenv(ROOT_DIR / ".env")
 from app import audio_pipeline  # noqa: E402
 from app.db import create_audio_job, get_audio_job  # noqa: E402
 
-mongo_url = os.environ["MONGO_URL"]
+# Allow the server to start even if MongoDB environment variables are missing.
+# This ensures features like the audio job endpoints work without requiring a
+# running Mongo instance. If the variables are not provided, sensible defaults
+# pointing to a local MongoDB are used. This mirrors FastAPI's
+# typical behaviour of lazy connections; the client will only
+# raise connection errors when a Mongo-dependent endpoint is called.
+mongo_url = os.getenv("MONGO_URL", "mongodb://localhost:27017")
+db_name = os.getenv("DB_NAME", "spotifree")
 client = AsyncIOMotorClient(mongo_url)
-db = client[os.environ["DB_NAME"]]
+db = client[db_name]
 
 DOWNLOAD_DIR = Path(os.getenv("DOWNLOAD_DIR", "/tmp/music_downloads"))
 DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)

--- a/test_result.md
+++ b/test_result.md
@@ -114,11 +114,14 @@ backend:
       - working: true
         agent: "main"
         comment: "Implemented submit, status and download endpoints."
+      - working: true
+        agent: "main"
+        comment: "Allow job submission without Mongo env vars; added regression test."
 frontend: []
 metadata:
   created_by: "main_agent"
   version: "1.0"
-  test_sequence: 1
+  test_sequence: 2
   run_ui: false
 test_plan:
   current_focus:
@@ -128,4 +131,4 @@ test_plan:
   test_priority: "high_first"
 agent_communication:
   - agent: "main"
-    message: "Implemented backend endpoints and ran tests."
+    message: "Allow audio job submission without Mongo env vars and added tests."

--- a/tests/test_audio_job.py
+++ b/tests/test_audio_job.py
@@ -1,0 +1,22 @@
+import asyncio
+import importlib
+import sys
+from fastapi import BackgroundTasks
+
+
+def test_submit_audio_without_mongo_env(tmp_path, monkeypatch):
+    """Server should start and allow job submission without Mongo env vars."""
+    # Remove environment variables and isolate working directory
+    monkeypatch.delenv("MONGO_URL", raising=False)
+    monkeypatch.delenv("DB_NAME", raising=False)
+    monkeypatch.chdir(tmp_path)
+    # Ensure modules are reloaded with new environment
+    sys.modules.pop("app.db", None)
+    sys.modules.pop("backend.server", None)
+    server = importlib.import_module("backend.server")
+    importlib.reload(server)
+
+    req = server.SubmitRequest(url="http://example.com")
+    result = asyncio.run(server.submit_audio(req, BackgroundTasks()))
+    assert result["status"] == "queued"
+    assert "audio_id" in result


### PR DESCRIPTION
## Summary
- avoid hard crash when MongoDB environment variables are missing by providing defaults
- add regression test ensuring audio job submission works without MongoDB configuration

## Testing
- `black backend/server.py tests/test_audio_job.py`
- `flake8 backend/server.py tests/test_audio_job.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b049cf59ec8333a4a4f35fa4f2946a