### PR TITLE
fix: default API port and document backend url

### DIFF
--- a/YOUTUBE_DOWNLOADER_README.md
+++ b/YOUTUBE_DOWNLOADER_README.md
@@ -72,6 +72,8 @@ Les endpoints suivants sont disponibles :
 
 ### Variables d'environnement :
 - `YT_DLP_PROXY` : URL du proxy HTTP à utiliser par `yt-dlp` (optionnel)
+- `REACT_APP_API_URL` : URL de base du backend pour le frontend.
+  - Par défaut, l'application tente d'appeler `http://<hôte>:10000`.
 
 ## 🛡️ Sécurité et limitations
 

--- a/frontend/src/components/VideoDownloader.jsx
+++ b/frontend/src/components/VideoDownloader.jsx
@@ -6,9 +6,10 @@ import { Progress } from "./ui/progress";
 
 // Create an axios instance with a configurable base URL so that the
 // frontend can communicate with a backend hosted on a different origin.
-// Defaults to the local development server.
+// Defaults to the same host using the backend's expected port (10000).
+const defaultApiUrl = `${window.location.protocol}//${window.location.hostname}:10000`;
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_URL || "http://localhost:8000",
+  baseURL: process.env.REACT_APP_API_URL || defaultApiUrl,
 });
 
 const VideoDownloader = () => {
@@ -46,7 +47,8 @@ const VideoDownloader = () => {
       setStatus(res.data.status);
       setProgress(0);
     } catch (e) {
-      setError("Création du job échouée");
+      const msg = e.response?.data?.detail || e.message || "Création du job échouée";
+      setError(msg);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- default frontend API to host:10000 and surface server error messages
- document REACT_APP_API_URL frontend setting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b04daad3b88333bb5ae7509344fea1