### PR TITLE
Fix CORS to allow audio submit endpoint

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -40,9 +40,7 @@ DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
 FFMPEG_BINARY = imageio_ffmpeg.get_ffmpeg_exe()
 
-from fastapi.middleware.cors import CORSMiddleware
 app = FastAPI()
-app.add_middleware(CORSMiddleware, allow_origins=[""], allow_credentials=True, allow_methods=[""], allow_headers=["*"])
 
 ALLOWED_ORIGINS = [
     o for o in [os.getenv("FRONTEND_ORIGIN"), "http://localhost:3000"] if o
@@ -50,6 +48,7 @@ ALLOWED_ORIGINS = [
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["*"],
     expose_headers=["Content-Disposition"],


### PR DESCRIPTION
## Summary
- clean up FastAPI CORS configuration
- allow POST requests to the audio submit endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0b46c363483339baa684e6020d55a