### PR TITLE
fix local player blob URLs and external API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 - **Build Command:** `npm run build`
 - **Output Directory:** `build`
 
+### API Keys
+
+- The frontend optionally uses the Last.fm API for artist images.
+  Define `REACT_APP_LASTFM_API_KEY` in your environment to supply your own
+  Last.fm API key. Without this key the application will gracefully skip
+  fetching artist images from Last.fm.
+
 ### Render
 - **Build Command:** `pip install -r requirements.txt`
 - **Start Command:** `uvicorn server:app --host 0.0.0.0 --port 10000`

--- a/frontend/src/components/LocalPlayer.jsx
+++ b/frontend/src/components/LocalPlayer.jsx
@@ -13,15 +13,21 @@ export default function LocalPlayer() {
   const [cur, setCur] = useState(0);
   const [vol, setVol] = useState([70]); // 0..100 for Slider component
 
-  // Cleanup blob URLs on change/unmount
+  // Cleanup blob URLs when the component unmounts
   useEffect(() => {
-    return () => tracks.forEach(t => URL.revokeObjectURL(t.url));
-  }, [tracks]);
+    return () => {
+      tracks.forEach(t => URL.revokeObjectURL(t.url));
+    };
+  }, []);
 
   const onPick = (e) => {
+    // Revoke any previously created object URLs before loading new files
+    tracks.forEach(t => URL.revokeObjectURL(t.url));
+
     const next = Array.from(e.target.files || [])
       .filter(f => f.type.startsWith("audio/") || f.name.toLowerCase().endsWith(".mp3"))
       .map(f => ({ name: f.name.replace(/\.[^/.]+$/, ""), url: URL.createObjectURL(f) }));
+
     setTracks(next);
     setI(0);
     setPlaying(false);

--- a/frontend/src/services/musicBrainz.js
+++ b/frontend/src/services/musicBrainz.js
@@ -2,7 +2,10 @@
 const MUSICBRAINZ_API = 'https://musicbrainz.org/ws/2';
 const COVERART_API = 'https://coverartarchive.org';
 const LASTFM_API = 'https://ws.audioscrobbler.com/2.0';
-const LASTFM_API_KEY = '7ac0e7a8d3e3bb2cde00c2b0d8e63b9f'; // Public key for testing
+// Last.fm API key is now provided via environment variable to avoid hard-coding
+// sensitive or rate-limited credentials. Users should define
+// REACT_APP_LASTFM_API_KEY in their environment when running the frontend.
+const LASTFM_API_KEY = process.env.REACT_APP_LASTFM_API_KEY;
 
 // Cache for artist data to avoid repeated requests
 const artistCache = new Map();
@@ -74,6 +77,12 @@ export const getArtistImage = async (artistName) => {
   const cacheKey = artistName.toLowerCase().trim();
   if (imageCache.has(cacheKey)) {
     return imageCache.get(cacheKey);
+  }
+
+  // Do not attempt the Last.fm request if no API key is configured
+  if (!LASTFM_API_KEY) {
+    console.warn('Last.fm API key not configured');
+    return null;
   }
 
   try {


### PR DESCRIPTION
## Summary
- load local MP3 files reliably by revoking object URLs only when needed
- read Last.fm API key from env and skip request when missing
- document required Last.fm API key env var

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0b5340b408333a2f72682dfacd670