### PR TITLE
Ensure POST submission and surface HTTP codes

### DIFF
--- a/frontend/src/components/VideoDownloader.jsx
+++ b/frontend/src/components/VideoDownloader.jsx
@@ -43,8 +43,7 @@ const VideoDownloader = () => {
       setStatus(res.data.status);
       setProgress(0);
     } catch (e) {
-      const msg = e.response?.data?.detail || e.message || "Création du job échouée";
-      setError(msg);
+      setError(`Échec (${e.response?.status || "?"})`);
     } finally {
       setLoading(false);
     }
@@ -64,8 +63,8 @@ const VideoDownloader = () => {
         if (res.data.status === "done") {
           downloadFile(audioId);
         }
-      } catch (_e) {
-        setError("Impossible de récupérer le statut");
+      } catch (e) {
+        setError(`Impossible de récupérer le statut (${e.response?.status || "?"})`);
         clearInterval(id);
       }
     }, 1000);


### PR DESCRIPTION
## Summary
- Show HTTP status codes on submission or polling failures in VideoDownloader to aid debugging.
- VideoDownloader uses POST `/api/audio/submit` and GET for status/download via shared axios client.

## Testing
- `pytest -q`
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c799297c8333badad7f382c9e2a1