### PR TITLE
Configure CORS middleware for Vercel fronts

### DIFF
--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -2,8 +2,8 @@ services:
   - type: web
     name: spotifree-backend
     runtime: python3.11
-    buildCommand: "pip install -r requirements.txt"
-    startCommand: "uvicorn server:app --host 0.0.0.0 --port 10000"
+    buildCommand: "pip install -r backend/requirements.txt"
+    startCommand: "uvicorn backend.server:app --host 0.0.0.0 --port $PORT"
     envVars:
-      - key: PORT
-        value: 10000
+      - key: CORS_ORIGIN_REGEX
+        value: "^https://.*.vercel.app$"

--- a/backend/server.py
+++ b/backend/server.py
@@ -5,15 +5,28 @@ from pydantic import BaseModel
 from app import audio_pipeline
 from app.db import create_audio_job, get_audio_job
 
+import os
+from fastapi.middleware.cors import CORSMiddleware
+
 app = FastAPI()
 
-from fastapi.middleware.cors import CORSMiddleware
+cors_origins_env = os.getenv("CORS_ORIGINS")
+allow_origins = (
+    [o.strip() for o in cors_origins_env.split(",") if o.strip()]
+    if cors_origins_env
+    else []
+)
+allow_origin_regex = os.getenv(
+    "CORS_ORIGIN_REGEX", r"^https://.*\.vercel\.app$"
+)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
+    allow_origins=allow_origins,
+    allow_origin_regex=allow_origin_regex,
+    allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["*"],
+    expose_headers=["Content-Disposition"],
+    allow_credentials=False,
 )
 
 api_router = APIRouter(prefix="/api")


### PR DESCRIPTION
## Summary
- configure FastAPI CORS middleware using env vars, allow Vercel previews and expose download headers
- update Render configuration to install backend requirements and run backend.server app

## Testing
- `pytest`
- `curl -i -X OPTIONS http://localhost:8000/api/health -H "Origin: https://example.vercel.app" -H "Access-Control-Request-Method: GET"`
- `curl -i http://localhost:8000/api/health -H "Origin: https://example.vercel.app"`


------
https://chatgpt.com/codex/tasks/task_e_68b5d70363308333a1ffd2d867952c12