### PR TITLE
Use runtime origin as default API base

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,7 +4,7 @@ const DEFAULT_API_BASE = "https://spotifree-backend.onrender.com";
 
 export const API_BASE =
   (envApiBase && envApiBase.trim()) ||
-  (runtimeBase && runtimeBase.includes("localhost") ? runtimeBase : DEFAULT_API_BASE);
+  (runtimeBase && /^https?:\/\//.test(runtimeBase) ? runtimeBase : DEFAULT_API_BASE);
 
 const API_ROOT = API_BASE.replace(/\/+$/, "");
 


### PR DESCRIPTION
## Summary
- prefer the page origin for API calls when no explicit API base is set
- keep render backend as fallback

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a0c390a88333bdc6dedf86a90839)