### PR TITLE
Add yt-dlp download interface

### DIFF
--- a/app/audio_pipeline.py
+++ b/app/audio_pipeline.py
@@ -1,37 +1,75 @@
-"""Audio processing pipeline used by background tasks.
+"""yt-dlp processing pipeline used by background tasks.
 
-This module downloads the best available audio stream from a video URL using
-``yt-dlp`` and converts it to an MP3 file via ``ffmpeg``. Progress and status
-updates are written to the SQLite database so that the API can report real-time
-information to clients.
+This module drives the bundled ``yt-dlp`` integration. It can download the best
+available audio and convert it to MP3, or download a merged MP4 video, while
+persisting progress updates to SQLite for the UI.
 """
 
-# INSERT START: imports
-import glob
+from __future__ import annotations
+
 import math
+import mimetypes
 import os
 import random
 import subprocess
 import tempfile
 import time
 from pathlib import Path
+from typing import Any, Dict
 
-import imageio_ffmpeg
 import yt_dlp
 
 from .db import AUDIO_DIR, get_audio_job, update_audio_job
 
-# INSERT END: imports
+SUPPORTED_OUTPUT_FORMATS = {"mp3", "mp4"}
+SUPPORTED_BITRATES = {128, 192, 256, 320}
 
-# INSERT START: pipeline
+
+def normalize_output_format(value: Any) -> str:
+    """Return a safe output format accepted by the downloader."""
+
+    normalized = str(value or "mp3").strip().lower()
+    if normalized not in SUPPORTED_OUTPUT_FORMATS:
+        raise ValueError("Format de sortie non supporté. Choisissez mp3 ou mp4.")
+    return normalized
+
+
+def normalize_bitrate(value: Any) -> int:
+    """Return a safe audio bitrate in kbps."""
+
+    try:
+        bitrate = int(value or 192)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Bitrate invalide.") from exc
+    if bitrate not in SUPPORTED_BITRATES:
+        raise ValueError("Bitrate non supporté. Choisissez 128, 192, 256 ou 320 kbps.")
+    return bitrate
+
+
+def ytdlp_runtime_info() -> Dict[str, Any]:
+    """Expose runtime details used by the frontend status panel."""
+
+    return {
+        "name": "yt-dlp",
+        "project_url": "https://github.com/yt-dlp/yt-dlp",
+        "version": getattr(yt_dlp.version, "__version__", "unknown"),
+        "output_formats": sorted(SUPPORTED_OUTPUT_FORMATS),
+        "audio_bitrates": sorted(SUPPORTED_BITRATES),
+    }
+
+
+def media_type_for_path(path: Path) -> str:
+    """Return the HTTP media type for a generated file."""
+
+    if path.suffix.lower() == ".mp3":
+        return "audio/mpeg"
+    if path.suffix.lower() == ".mp4":
+        return "video/mp4"
+    return mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+
 
 def process_audio_job(audio_id: str) -> None:
-    """Download the audio for ``audio_id`` and convert it to MP3.
-
-    Parameters
-    ----------
-    audio_id: Identifier of the audio job in the database.
-    """
+    """Download and convert a yt-dlp job to the requested output format."""
 
     try:
         job = get_audio_job(audio_id)
@@ -39,7 +77,12 @@ def process_audio_job(audio_id: str) -> None:
             return
 
         source_url = job["source_url"]
-        update_audio_job(audio_id, status="downloading", progress=0, message="")
+        output_format = normalize_output_format(job.get("output_format"))
+        bitrate = normalize_bitrate(job.get("bitrate"))
+
+        update_audio_job(audio_id, status="downloading", progress=0, message="Initialisation de yt-dlp…")
+
+        import imageio_ffmpeg
 
         ffmpeg_exe = imageio_ffmpeg.get_ffmpeg_exe()
 
@@ -47,89 +90,152 @@ def process_audio_job(audio_id: str) -> None:
             if d.get("status") == "downloading":
                 total = d.get("total_bytes") or d.get("total_bytes_estimate")
                 if total:
-                    pct = math.ceil(d["downloaded_bytes"] * 80 / total)
-                    update_audio_job(audio_id, status="downloading", progress=pct)
+                    pct = math.ceil(d.get("downloaded_bytes", 0) * 80 / total)
+                    update_audio_job(
+                        audio_id,
+                        status="downloading",
+                        progress=max(1, min(80, pct)),
+                        message="Téléchargement avec yt-dlp…",
+                    )
+            elif d.get("status") == "finished":
+                update_audio_job(audio_id, status="converting", progress=85, message="Téléchargement terminé.")
 
-        headers = {
-            "User-Agent": (
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
-            ),
-            "Referer": "https://www.youtube.com/",
-            "Accept-Language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
-        }
-
-        ydl_opts = {
-            "format": "bestaudio/best",
-            "noplaylist": True,
-            "quiet": True,
-            "no_warnings": True,
-            "retries": 20,
-            "fragment_retries": 20,
-            "concurrent_fragment_downloads": 1,
-            "socket_timeout": 30,
-            "prefer_free_formats": True,
-            "geo_bypass": True,
-            "http_headers": headers,
-            "extractor_args": {"youtube": {"player_client": ["android", "web"]}},
-            "ffmpeg_location": ffmpeg_exe,
-            "progress_hooks": [progress_hook],
-        }
-
-        cookiefile = os.getenv("COOKIES_TXT")
-        if cookiefile and Path(cookiefile).is_file():
-            ydl_opts["cookiefile"] = cookiefile
+        ydl_opts = _base_ytdlp_options(ffmpeg_exe, progress_hook)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
-            ydl_opts["outtmpl"] = str(tmp_path / "source.%(ext)s")
-
-            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-                info = ydl.extract_info(source_url, download=True)
-
-            update_audio_job(
-                audio_id,
-                title=info.get("title"),
-                duration_s=info.get("duration"),
-            )
-
-            time.sleep(random.uniform(0.2, 0.6))
-
-            downloaded = list(tmp_path.glob("source.*"))
-            if not downloaded:
-                raise RuntimeError("Download failed")
-            source_file = downloaded[0]
-
-            update_audio_job(audio_id, status="converting", progress=90)
-            output_file = AUDIO_DIR / f"{audio_id}.mp3"
-
-            ff_cmd = [
-                ffmpeg_exe,
-                "-y",
-                "-i",
-                str(source_file),
-                "-vn",
-                "-ar",
-                "44100",
-                "-ac",
-                "2",
-                "-b:a",
-                "192k",
-            ]
-            if info.get("title"):
-                ff_cmd += ["-metadata", f"title={info['title']}"]
-            ff_cmd.append(str(output_file))
-
-            subprocess.run(ff_cmd, check=True)
+            if output_format == "mp4":
+                output_file, info = _download_mp4(source_url, audio_id, tmp_path, ydl_opts)
+            else:
+                output_file, info = _download_mp3(source_url, audio_id, bitrate, tmp_path, ydl_opts, ffmpeg_exe)
 
         update_audio_job(
             audio_id,
             status="done",
             progress=100,
+            message="Terminé",
+            title=info.get("title"),
+            duration_s=info.get("duration"),
             filepath_mp3=str(output_file),
         )
     except Exception as exc:  # pragma: no cover - safety net
         update_audio_job(audio_id, status="error", message=str(exc))
 
-# INSERT END: pipeline
 
+def _base_ytdlp_options(ffmpeg_exe: str, progress_hook) -> Dict[str, Any]:
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+        ),
+        "Referer": "https://www.youtube.com/",
+        "Accept-Language": "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
+    }
+    options: Dict[str, Any] = {
+        "noplaylist": True,
+        "quiet": True,
+        "no_warnings": True,
+        "retries": 20,
+        "fragment_retries": 20,
+        "concurrent_fragment_downloads": 1,
+        "socket_timeout": 30,
+        "prefer_free_formats": True,
+        "geo_bypass": True,
+        "http_headers": headers,
+        "extractor_args": {"youtube": {"player_client": ["android", "web"]}},
+        "ffmpeg_location": ffmpeg_exe,
+        "progress_hooks": [progress_hook],
+    }
+
+    cookiefile = os.getenv("COOKIES_TXT")
+    if cookiefile and Path(cookiefile).is_file():
+        options["cookiefile"] = cookiefile
+
+    return options
+
+
+def _download_mp3(
+    source_url: str,
+    audio_id: str,
+    bitrate: int,
+    tmp_path: Path,
+    ydl_opts: Dict[str, Any],
+    ffmpeg_exe: str,
+) -> tuple[Path, Dict[str, Any]]:
+    ydl_opts = {
+        **ydl_opts,
+        "format": "bestaudio/best",
+        "outtmpl": str(tmp_path / "source.%(ext)s"),
+    }
+
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(source_url, download=True)
+
+    update_audio_job(
+        audio_id,
+        title=info.get("title"),
+        duration_s=info.get("duration"),
+        status="converting",
+        progress=90,
+        message="Conversion MP3 avec ffmpeg…",
+    )
+
+    time.sleep(random.uniform(0.2, 0.6))
+    downloaded = list(tmp_path.glob("source.*"))
+    if not downloaded:
+        raise RuntimeError("Téléchargement échoué : aucun fichier source généré.")
+
+    output_file = AUDIO_DIR / f"{audio_id}.mp3"
+    ff_cmd = [
+        ffmpeg_exe,
+        "-y",
+        "-i",
+        str(downloaded[0]),
+        "-vn",
+        "-ar",
+        "44100",
+        "-ac",
+        "2",
+        "-b:a",
+        f"{bitrate}k",
+    ]
+    if info.get("title"):
+        ff_cmd += ["-metadata", f"title={info['title']}"]
+    ff_cmd.append(str(output_file))
+    subprocess.run(ff_cmd, check=True)
+    return output_file, info
+
+
+def _download_mp4(
+    source_url: str,
+    audio_id: str,
+    tmp_path: Path,
+    ydl_opts: Dict[str, Any],
+) -> tuple[Path, Dict[str, Any]]:
+    output_file = AUDIO_DIR / f"{audio_id}.mp4"
+    ydl_opts = {
+        **ydl_opts,
+        "format": "bv*[height<=1080]+ba/b[height<=1080]/best",
+        "merge_output_format": "mp4",
+        "outtmpl": str(tmp_path / "source.%(ext)s"),
+        "postprocessor_hooks": [
+            lambda _: update_audio_job(
+                audio_id,
+                status="converting",
+                progress=92,
+                message="Fusion MP4 avec ffmpeg…",
+            )
+        ],
+        "paths": {"home": str(tmp_path)},
+    }
+
+    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+        info = ydl.extract_info(source_url, download=True)
+        downloaded = Path(ydl.prepare_filename(info)).with_suffix(".mp4")
+
+    candidates = [downloaded, *tmp_path.glob("source*.mp4")]
+    source_file = next((candidate for candidate in candidates if candidate.is_file()), None)
+    if not source_file:
+        raise RuntimeError("Téléchargement échoué : aucun fichier MP4 généré.")
+    source_file.replace(output_file)
+    return output_file, info

--- a/app/db.py
+++ b/app/db.py
@@ -24,6 +24,8 @@ class Audio:
         self.id: str = data.get("id", str(uuid.uuid4()))
         self.created_at: datetime = data.get("created_at", datetime.utcnow())
         self.source_url: str = data["source_url"]
+        self.output_format: str = data.get("output_format", "mp3")
+        self.bitrate: int = int(data.get("bitrate") or 192)
         self.status: str = data.get("status", "queued")
         self.progress: int = data.get("progress", 0)
         self.message: str = data.get("message", "")
@@ -36,6 +38,8 @@ class Audio:
             "id": self.id,
             "created_at": self.created_at.isoformat(),
             "source_url": self.source_url,
+            "output_format": self.output_format,
+            "bitrate": self.bitrate,
             "status": self.status,
             "progress": self.progress,
             "message": self.message,
@@ -55,6 +59,8 @@ def init_db() -> None:
             id TEXT PRIMARY KEY,
             created_at TEXT,
             source_url TEXT,
+            output_format TEXT DEFAULT 'mp3',
+            bitrate INTEGER DEFAULT 192,
             status TEXT,
             progress INTEGER,
             message TEXT,
@@ -64,24 +70,34 @@ def init_db() -> None:
         )
         """
     )
+    existing_columns = {row[1] for row in _conn.execute("PRAGMA table_info(audio)").fetchall()}
+    migrations = {
+        "output_format": "ALTER TABLE audio ADD COLUMN output_format TEXT DEFAULT 'mp3'",
+        "bitrate": "ALTER TABLE audio ADD COLUMN bitrate INTEGER DEFAULT 192",
+    }
+    for column, statement in migrations.items():
+        if column not in existing_columns:
+            _conn.execute(statement)
     _conn.commit()
 
 # INSERT END: init_db
 
 # INSERT START: CRUD
 
-def create_audio_job(source_url: str) -> str:
-    audio = Audio(source_url=source_url)
+def create_audio_job(source_url: str, output_format: str = "mp3", bitrate: int = 192) -> str:
+    audio = Audio(source_url=source_url, output_format=output_format, bitrate=bitrate)
     _conn.execute(
         """
         INSERT INTO audio (
-            id, created_at, source_url, status, progress, message, title, duration_s, filepath_mp3
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            id, created_at, source_url, output_format, bitrate, status, progress, message, title, duration_s, filepath_mp3
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             audio.id,
             audio.created_at.isoformat(),
             audio.source_url,
+            audio.output_format,
+            audio.bitrate,
             audio.status,
             audio.progress,
             audio.message,

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ DATA_DIR.mkdir(parents=True, exist_ok=True)
 class JobRequest(BaseModel):
     url: str
     bitrate: Optional[int] = None
+    output_format: Optional[str] = "mp3"
 
 
 @app.get("/health")
@@ -44,13 +45,26 @@ async def health() -> dict[str, bool]:
     return {"ok": True}
 
 
+
+
+@app.get("/api/ytdlp/info")
+async def ytdlp_info() -> Dict[str, Any]:
+    return audio_pipeline.ytdlp_runtime_info()
+
+
 @app.post("/api/jobs")
 async def create_job(payload: JobRequest, background_tasks: BackgroundTasks) -> Dict[str, str]:
     source_url = payload.url.strip()
     if not source_url:
         raise HTTPException(status_code=400, detail="URL is required")
 
-    job_id = create_audio_job(source_url)
+    try:
+        output_format = audio_pipeline.normalize_output_format(payload.output_format)
+        bitrate = audio_pipeline.normalize_bitrate(payload.bitrate)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    job_id = create_audio_job(source_url, output_format=output_format, bitrate=bitrate)
     background_tasks.add_task(audio_pipeline.process_audio_job, job_id)
     return {"job_id": job_id}
 
@@ -71,6 +85,8 @@ async def job_status(job_id: str) -> Dict[str, Any]:
         "title": job.get("title"),
         "duration_s": job.get("duration_s"),
         "created_at": job.get("created_at").isoformat() if job.get("created_at") else None,
+        "output_format": job.get("output_format", "mp3"),
+        "bitrate": job.get("bitrate", 192),
         "download_url": f"/api/download/{job_id}" if download_ready else None,
     }
 
@@ -78,6 +94,9 @@ async def job_status(job_id: str) -> Dict[str, Any]:
 @app.get("/api/download/{job_id}")
 async def download(job_id: str):
     file_path = (DATA_DIR / f"{job_id}.mp3").resolve()
+    mp4_path = (DATA_DIR / f"{job_id}.mp4").resolve()
+    if not file_path.is_file() and mp4_path.is_file():
+        file_path = mp4_path
 
     if not file_path.is_file():
         job = get_audio_job(job_id)
@@ -93,7 +112,7 @@ async def download(job_id: str):
 
     return FileResponse(
         path=file_path,
-        media_type="audio/mpeg",
+        media_type=audio_pipeline.media_type_for_path(file_path),
         filename=file_path.name,
         headers={"Cache-Control": "no-store"},
     )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.27.1
-yt-dlp==2024.03.10
+yt-dlp @ https://github.com/yt-dlp/yt-dlp/archive/refs/heads/master.zip
 ffmpeg-python==0.2.0
 imageio-ffmpeg==0.4.9
 mutagen==1.47.0
@@ -8,3 +8,4 @@ pydantic==1.10.18
 python-multipart==0.0.9
 slowapi==0.1.8
 tenacity==8.2.3
+setuptools>=70

--- a/backend/server.py
+++ b/backend/server.py
@@ -45,6 +45,15 @@ class SubmitRequest(BaseModel):
 class JobRequest(BaseModel):
     url: str
     bitrate: int | None = None
+    output_format: str | None = "mp3"
+
+
+
+
+@api_router.get("/ytdlp/info")
+@api_router.get("/ytdlp/info/")
+async def ytdlp_info():
+    return audio_pipeline.ytdlp_runtime_info()
 
 
 @api_router.post("/audio/submit")
@@ -79,7 +88,7 @@ async def audio_download(audio_id: str):
     job = get_audio_job(audio_id)
     if not job or not job.get("filepath_mp3"):
         raise HTTPException(status_code=404, detail="File not ready")
-    return FileResponse(job["filepath_mp3"], media_type="audio/mpeg")
+    return FileResponse(job["filepath_mp3"], media_type=audio_pipeline.media_type_for_path(Path(job["filepath_mp3"])))
 
 
 # --- Compatibility endpoints used by the frontend ---
@@ -94,7 +103,13 @@ async def create_job(req: JobRequest, background_tasks: BackgroundTasks):
     if not source_url:
         raise HTTPException(status_code=400, detail="URL is required")
 
-    job_id = create_audio_job(source_url)
+    try:
+        output_format = audio_pipeline.normalize_output_format(req.output_format)
+        bitrate = audio_pipeline.normalize_bitrate(req.bitrate)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    job_id = create_audio_job(source_url, output_format=output_format, bitrate=bitrate)
     background_tasks.add_task(audio_pipeline.process_audio_job, job_id)
     return {"job_id": job_id}
 
@@ -116,6 +131,8 @@ async def job_status(job_id: str):
         "title": job.get("title"),
         "duration_s": job.get("duration_s"),
         "created_at": job.get("created_at").isoformat() if job.get("created_at") else None,
+        "output_format": job.get("output_format", "mp3"),
+        "bitrate": job.get("bitrate", 192),
         "download_url": f"/api/download/{job_id}" if download_ready else None,
     }
 
@@ -126,6 +143,9 @@ async def job_status(job_id: str):
 @api_router.head("/download/{job_id}/")
 async def download(job_id: str):
     file_path = (DATA_DIR / f"{job_id}.mp3").resolve()
+    mp4_path = (DATA_DIR / f"{job_id}.mp4").resolve()
+    if not file_path.is_file() and mp4_path.is_file():
+        file_path = mp4_path
 
     if not file_path.is_file():
         job = get_audio_job(job_id)
@@ -141,7 +161,7 @@ async def download(job_id: str):
 
     return FileResponse(
         path=file_path,
-        media_type="audio/mpeg",
+        media_type=audio_pipeline.media_type_for_path(file_path),
         filename=file_path.name,
         headers={"Cache-Control": "no-store"},
     )

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -33,3 +33,13 @@ export async function getJob(jobId) {
   }
   return response.json();
 }
+
+
+export async function getYtDlpInfo() {
+  const response = await fetch(`${API_ROOT}/api/ytdlp/info`);
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw Object.assign(new Error("Impossible de récupérer les informations yt-dlp"), { response, error });
+  }
+  return response.json();
+}

--- a/frontend/src/components/VideoDownloader.jsx
+++ b/frontend/src/components/VideoDownloader.jsx
@@ -1,21 +1,32 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { API_BASE, createJob, getJob } from "../api";
+import { API_BASE, createJob, getJob, getYtDlpInfo } from "../api";
 import { Input } from "./ui/input";
 import { Button } from "./ui/button";
 import { Progress } from "./ui/progress";
+import { Badge } from "./ui/badge";
 
-const STORAGE_KEY = "spotifree.jobs";
+const STORAGE_KEY = "spotifree.ytdlp.jobs";
 const API_ROOT = API_BASE.replace(/\/+$/, "");
 
 const BITRATES = [128, 192, 256, 320];
+const OUTPUT_FORMATS = [
+  { id: "mp3", label: "Audio MP3", description: "Extrait la meilleure piste audio puis convertit en MP3." },
+  { id: "mp4", label: "Vidéo MP4", description: "Télécharge et fusionne la meilleure vidéo jusqu'à 1080p." },
+];
 
 const initialForm = {
   url: "",
+  output_format: "mp3",
   bitrate: 192,
-  title: "",
-  artist: "",
-  album: "",
 };
+
+const extractApiMessage = (error, fallback) =>
+  error?.error?.detail?.error?.message ||
+  error?.error?.detail ||
+  error?.error?.error?.message ||
+  error?.error?.message ||
+  error?.message ||
+  fallback;
 
 const VideoDownloader = () => {
   const [form, setForm] = useState(initialForm);
@@ -23,6 +34,8 @@ const VideoDownloader = () => {
   const [submitting, setSubmitting] = useState(false);
   const [jobs, setJobs] = useState([]);
   const [downloadingJobId, setDownloadingJobId] = useState(null);
+  const [toolInfo, setToolInfo] = useState(null);
+  const [toolInfoError, setToolInfoError] = useState("");
   const pollers = useRef({});
 
   useEffect(() => {
@@ -36,15 +49,33 @@ const VideoDownloader = () => {
         }
       }
     } catch (storageError) {
-      console.warn("Unable to load stored jobs", storageError);
+      console.warn("Unable to load stored yt-dlp jobs", storageError);
     }
   }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const snapshot = jobs.slice(0, 10);
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(jobs.slice(0, 10)));
   }, [jobs]);
+
+  useEffect(() => {
+    let mounted = true;
+    getYtDlpInfo()
+      .then((info) => {
+        if (mounted) {
+          setToolInfo(info);
+          setToolInfoError("");
+        }
+      })
+      .catch((infoError) => {
+        if (mounted) {
+          setToolInfoError(extractApiMessage(infoError, "yt-dlp est indisponible côté API."));
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -61,9 +92,8 @@ const VideoDownloader = () => {
   }, [jobs]);
 
   const startPolling = (jobId) => {
-    if (!jobId || pollers.current[jobId]) {
-      return;
-    }
+    if (!jobId || pollers.current[jobId]) return;
+
     const tick = async () => {
       try {
         const status = await getJob(jobId);
@@ -76,10 +106,11 @@ const VideoDownloader = () => {
         stopPolling(jobId);
         updateJob(jobId, {
           status: "error",
-          message: pollError?.error?.error?.message || "Erreur réseau",
+          message: extractApiMessage(pollError, "Erreur réseau"),
         });
       }
     };
+
     pollers.current[jobId] = setInterval(tick, 1000);
     tick();
   };
@@ -114,40 +145,36 @@ const VideoDownloader = () => {
   };
 
   const handleSubmit = async () => {
-    if (!form.url) {
-      setError("Veuillez saisir une URL valide.");
+    if (!form.url.trim()) {
+      setError("Veuillez saisir une URL compatible avec yt-dlp.");
       return;
     }
+
     setSubmitting(true);
     setError("");
     try {
       const payload = {
-        url: form.url,
-        bitrate: form.bitrate,
-        title: form.title || undefined,
-        artist: form.artist || undefined,
-        album: form.album || undefined,
+        url: form.url.trim(),
+        output_format: form.output_format,
+        bitrate: form.output_format === "mp3" ? form.bitrate : undefined,
       };
       const result = await createJob(payload);
       const jobId = result.job_id;
       const newJob = {
         job_id: jobId,
-        url: form.url,
-        bitrate: form.bitrate,
+        url: payload.url,
+        output_format: payload.output_format,
+        bitrate: payload.bitrate || form.bitrate,
         status: "queued",
         progress: 0,
         message: "En file d'attente",
         created_at: Date.now(),
       };
       setJobs((prev) => [newJob, ...prev.filter((job) => (job.job_id || job.id) !== jobId)].slice(0, 10));
+      setForm((prev) => ({ ...prev, url: "" }));
       startPolling(jobId);
     } catch (submitError) {
-      const message =
-        submitError?.error?.error?.message ||
-        submitError?.error?.message ||
-        submitError?.message ||
-        "Échec de la création du job.";
-      setError(message);
+      setError(extractApiMessage(submitError, "Échec de la création du job yt-dlp."));
     } finally {
       setSubmitting(false);
     }
@@ -156,17 +183,16 @@ const VideoDownloader = () => {
   const downloadHref = (jobId) => `${API_ROOT}/api/download/${jobId}`;
 
   const sanitizeFilename = useMemo(
-    () =>
-      (name) => {
-        const value = `${name ?? ""}`;
-        return value
-          .normalize("NFKD")
-          .replace(/[\u0300-\u036f]/g, "")
-          .replace(/[^\w\s-]+/g, "")
-          .trim()
-          .replace(/[\s_-]+/g, "-")
-          .replace(/^-+|-+$/g, "");
-      },
+    () => (name) => {
+      const value = `${name ?? ""}`;
+      return value
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/[^\w\s-]+/g, "")
+        .trim()
+        .replace(/[\s_-]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+    },
     []
   );
 
@@ -180,8 +206,8 @@ const VideoDownloader = () => {
 
       const response = await fetch(downloadHref(jobId), { mode: "cors" });
       if (!response.ok) {
-        const error = await response.json().catch(() => ({}));
-        throw new Error(error?.error?.message || "Téléchargement impossible.");
+        const errorBody = await response.json().catch(() => ({}));
+        throw new Error(extractApiMessage({ error: errorBody }, "Téléchargement impossible."));
       }
 
       const blob = await response.blob();
@@ -193,132 +219,155 @@ const VideoDownloader = () => {
       if (utfMatch?.[1]) {
         try {
           fromHeader = decodeURIComponent(utfMatch[1]);
-        } catch (error) {
+        } catch (decodeError) {
           fromHeader = utfMatch[1];
         }
       } else {
         const quotedMatch = disposition.match(/filename="?([^";]+)"?/i);
-        if (quotedMatch?.[1]) {
-          fromHeader = quotedMatch[1];
-        }
+        if (quotedMatch?.[1]) fromHeader = quotedMatch[1];
       }
+
+      const extension = (job.output_format || "mp3").toLowerCase();
       const title = fromHeader || job?.title || job?.url || jobId;
-      const safeTitle = sanitizeFilename(title) || `spotifree-${jobId}`;
+      const safeTitle = sanitizeFilename(title.replace(/\.(mp3|mp4)$/i, "")) || `spotifree-${jobId}`;
       anchor.href = downloadUrl;
-      anchor.download = `${safeTitle}.mp3`;
+      anchor.download = `${safeTitle}.${extension}`;
       document.body.appendChild(anchor);
       anchor.click();
       anchor.remove();
       URL.revokeObjectURL(downloadUrl);
     } catch (downloadError) {
-      let message = downloadError?.message || "Échec du téléchargement";
-      if (downloadError?.name === "TypeError") {
-        message = "Téléchargement impossible (connexion réseau ou CORS).";
-      }
       updateJob(jobId, {
-        message,
+        message:
+          downloadError?.name === "TypeError"
+            ? "Téléchargement impossible (connexion réseau ou CORS)."
+            : downloadError?.message || "Échec du téléchargement",
       });
     } finally {
       setDownloadingJobId((current) => (current === jobId ? null : current));
     }
   };
 
+  const selectedFormat = OUTPUT_FORMATS.find((format) => format.id === form.output_format) || OUTPUT_FORMATS[0];
+
   return (
-    <div className="w-full max-w-2xl mx-auto px-4 py-8 space-y-6">
-      <div className="bg-gray-900/60 border border-gray-800 rounded-2xl p-6 shadow-lg space-y-6">
-        <div className="space-y-2 text-center sm:text-left">
-          <h1 className="text-2xl font-bold text-white">Convertisseur vidéo vers MP3</h1>
-          <p className="text-sm text-gray-400">
-            Collez un lien vers une vidéo compatible, choisissez un bitrate, puis suivez la conversion en temps réel.
-          </p>
-        </div>
-
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <label className="text-xs uppercase tracking-wide text-gray-400">URL de la vidéo</label>
-            <Input
-              value={form.url}
-              onChange={handleInputChange("url")}
-              placeholder="https://www.youtube.com/watch?v=..."
-              className="bg-black/40 border-gray-700 focus:border-green-500 focus:ring-green-500"
-            />
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <div className="space-y-2">
-              <label className="text-xs uppercase tracking-wide text-gray-400">Bitrate</label>
-              <select
-                className="w-full rounded-md border border-gray-700 bg-black/40 px-3 py-2 text-sm text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
-                value={form.bitrate}
-                onChange={handleInputChange("bitrate")}
-              >
-                {BITRATES.map((option) => (
-                  <option key={option} value={option}>
-                    {option} kbps
-                  </option>
-                ))}
-              </select>
+    <div className="w-full max-w-5xl mx-auto px-4 py-8 space-y-6">
+      <div className="rounded-3xl border border-green-500/20 bg-gradient-to-br from-gray-950 via-gray-900 to-black p-6 shadow-2xl space-y-6">
+        <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge className="bg-green-500 text-black hover:bg-green-500">yt-dlp intégré</Badge>
+              <Badge variant="outline" className="border-gray-700 text-gray-300">
+                {toolInfo?.version ? `version ${toolInfo.version}` : "détection…"}
+              </Badge>
             </div>
-
-            <div className="space-y-2">
-              <label className="text-xs uppercase tracking-wide text-gray-400">Titre (facultatif)</label>
-              <Input
-                value={form.title}
-                onChange={handleInputChange("title")}
-                placeholder="Titre personnalisé"
-                className="bg-black/40 border-gray-700 focus:border-green-500 focus:ring-green-500"
-              />
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-xs uppercase tracking-wide text-gray-400">Artiste (facultatif)</label>
-              <Input
-                value={form.artist}
-                onChange={handleInputChange("artist")}
-                placeholder="Nom de l'artiste"
-                className="bg-black/40 border-gray-700 focus:border-green-500 focus:ring-green-500"
-              />
+            <div>
+              <h1 className="text-3xl font-bold text-white">Interface yt-dlp</h1>
+              <p className="mt-2 max-w-2xl text-sm text-gray-400">
+                Collez une URL compatible avec yt-dlp, choisissez une sortie MP3 ou MP4, puis téléchargez le fichier
+                généré directement depuis Spotifree.
+              </p>
             </div>
           </div>
-
-          <div className="space-y-2">
-            <label className="text-xs uppercase tracking-wide text-gray-400">Album (facultatif)</label>
-            <Input
-              value={form.album}
-              onChange={handleInputChange("album")}
-              placeholder="Nom de l'album"
-              className="bg-black/40 border-gray-700 focus:border-green-500 focus:ring-green-500"
-            />
-          </div>
-        </div>
-
-        <div className="flex flex-col sm:flex-row sm:items-center gap-3">
-          <Button
-            type="button"
-            onClick={handleSubmit}
-            disabled={submitting || !form.url}
-            className="w-full sm:w-auto bg-green-500 hover:bg-green-400 text-black font-semibold"
+          <a
+            href={toolInfo?.project_url || "https://github.com/yt-dlp/yt-dlp"}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center justify-center rounded-full border border-gray-700 px-4 py-2 text-sm font-semibold text-gray-200 hover:border-green-500 hover:text-green-300"
           >
-            {submitting ? "Conversion en cours…" : "Convertir en MP3"}
-          </Button>
-          <p className="text-xs text-gray-500">
-            Les conversions sont traitées par notre backend Render sécurisé avec sortie MP3 téléchargeable.
-          </p>
+            Voir le projet GitHub
+          </a>
         </div>
 
-        {error && (
-          <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-3 text-sm text-red-300">
-            {error}
+        {toolInfoError && (
+          <div className="rounded-lg border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm text-yellow-100">
+            {toolInfoError}
           </div>
         )}
+
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
+          <div className="space-y-5">
+            <div className="space-y-2">
+              <label className="text-xs uppercase tracking-wide text-gray-400">URL du média</label>
+              <Input
+                value={form.url}
+                onChange={handleInputChange("url")}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") handleSubmit();
+                }}
+                placeholder="https://www.youtube.com/watch?v=..."
+                className="bg-black/40 border-gray-700 focus:border-green-500 focus:ring-green-500"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {OUTPUT_FORMATS.map((format) => (
+                <button
+                  key={format.id}
+                  type="button"
+                  onClick={() => setForm((prev) => ({ ...prev, output_format: format.id }))}
+                  className={`rounded-2xl border p-4 text-left transition-colors ${
+                    form.output_format === format.id
+                      ? "border-green-500 bg-green-500/10 text-white"
+                      : "border-gray-800 bg-black/30 text-gray-300 hover:border-gray-600"
+                  }`}
+                >
+                  <span className="block text-sm font-semibold">{format.label}</span>
+                  <span className="mt-1 block text-xs text-gray-400">{format.description}</span>
+                </button>
+              ))}
+            </div>
+
+            {form.output_format === "mp3" && (
+              <div className="space-y-2">
+                <label className="text-xs uppercase tracking-wide text-gray-400">Bitrate MP3</label>
+                <select
+                  className="w-full rounded-md border border-gray-700 bg-black/40 px-3 py-2 text-sm text-white focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+                  value={form.bitrate}
+                  onChange={handleInputChange("bitrate")}
+                >
+                  {BITRATES.map((option) => (
+                    <option key={option} value={option}>
+                      {option} kbps
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                disabled={submitting || !form.url.trim()}
+                className="w-full sm:w-auto bg-green-500 hover:bg-green-400 text-black font-semibold"
+              >
+                {submitting ? "Lancement yt-dlp…" : `Télécharger en ${selectedFormat.id.toUpperCase()}`}
+              </Button>
+              <p className="text-xs text-gray-500">
+                yt-dlp tourne côté backend avec ffmpeg pour convertir ou fusionner le fichier final.
+              </p>
+            </div>
+
+            {error && <div className="rounded-lg border border-red-500/50 bg-red-500/10 p-3 text-sm text-red-300">{error}</div>}
+          </div>
+
+          <div className="rounded-2xl border border-gray-800 bg-black/30 p-4 text-sm text-gray-300 space-y-3">
+            <p className="font-semibold text-white">Fonctionnalités activées</p>
+            <ul className="space-y-2 text-gray-400">
+              <li>• Sortie audio MP3 128/192/256/320 kbps.</li>
+              <li>• Sortie vidéo MP4 avec fusion audio/vidéo.</li>
+              <li>• Suivi de progression et historique local.</li>
+              <li>• Téléchargement direct du fichier généré.</li>
+            </ul>
+          </div>
+        </div>
       </div>
 
-      <div className="space-y-4">
-        <h2 className="text-lg font-semibold text-white">Historique des conversions</h2>
+      <div className="rounded-2xl border border-gray-800 bg-gray-950/80 p-5 space-y-4">
+        <h2 className="text-lg font-semibold text-white">Jobs yt-dlp récents</h2>
         {jobs.length === 0 && (
-          <p className="text-sm text-gray-500">
-            Les jobs récents apparaîtront ici. Vous pourrez reprendre vos téléchargements terminés à tout moment.
-          </p>
+          <p className="text-sm text-gray-500">Aucun job pour le moment. Lancez un téléchargement pour le voir ici.</p>
         )}
         <div className="space-y-3">
           {jobs.map((job) => {
@@ -326,24 +375,21 @@ const VideoDownloader = () => {
             const isDone = job.status === "done";
             const isError = job.status === "error";
             const isDownloading = downloadingJobId === jobId;
+            const extension = (job.output_format || "mp3").toUpperCase();
 
             return (
-              <div
-                key={jobId}
-                className="rounded-xl border border-gray-800 bg-gray-900/40 p-4 space-y-3 shadow-sm"
-              >
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                  <div>
-                    <p className="text-sm font-semibold text-white break-words">{job.url}</p>
-                    <p className="text-xs text-gray-500">Bitrate&nbsp;: {job.bitrate} kbps</p>
+              <div key={jobId} className="rounded-xl border border-gray-800 bg-gray-900/50 p-4 space-y-3 shadow-sm">
+                <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-white break-words">{job.title || job.url}</p>
+                    <p className="text-xs text-gray-500 break-all">{job.url}</p>
+                    <p className="mt-1 text-xs text-gray-500">
+                      Sortie&nbsp;: {extension}{job.output_format === "mp3" ? ` · ${job.bitrate || 192} kbps` : " · vidéo 1080p max"}
+                    </p>
                   </div>
                   <span
                     className={`text-xs font-semibold uppercase tracking-wide ${
-                      isDone
-                        ? "text-green-400"
-                        : isError
-                        ? "text-red-400"
-                        : "text-blue-300"
+                      isDone ? "text-green-400" : isError ? "text-red-400" : "text-blue-300"
                     }`}
                   >
                     {job.status}
@@ -354,7 +400,7 @@ const VideoDownloader = () => {
                   <Progress value={job.progress || 0} className="h-2" />
                   <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between text-xs text-gray-400 gap-2">
                     <span>{job.progress ? `${job.progress}%` : "En attente…"}</span>
-                    <span className="text-gray-500">{job.message}</span>
+                    <span className={isError ? "text-red-300" : "text-gray-500"}>{job.message}</span>
                   </div>
                 </div>
 
@@ -365,26 +411,13 @@ const VideoDownloader = () => {
                     disabled={isDownloading}
                     className="inline-flex items-center justify-center rounded-md border border-green-500/70 bg-green-500/10 px-4 py-2 text-sm font-semibold text-green-300 hover:bg-green-500/20 disabled:opacity-50"
                   >
-                    {isDownloading ? "Téléchargement…" : "Télécharger le MP3"}
+                    {isDownloading ? "Téléchargement…" : `Télécharger le ${extension}`}
                   </button>
-                )}
-
-                {isError && job.message && (
-                  <p className="text-xs text-red-300">{job.message}</p>
                 )}
               </div>
             );
           })}
         </div>
-      </div>
-
-      <div className="rounded-xl border border-blue-500/30 bg-blue-500/10 p-4 text-sm text-blue-100">
-        <p className="font-semibold mb-2">Conseils rapides :</p>
-        <ul className="list-disc list-inside space-y-1">
-          <li>Évitez les vidéos protégées (DRM) ou diffusées en direct.</li>
-          <li>Les conversions prennent généralement moins d'une minute.</li>
-          <li>Depuis Vercel, vérifiez que la requête part bien vers Render (200 OK, sans redirection).</li>
-        </ul>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Integrate `yt-dlp` so the backend can download/convert video sources (YouTube etc.) and expose a simple, safe UI to run the tool from the app. 
- Support both audio (`mp3`) extraction and full video (`mp4`) downloads and allow users to choose bitrate/output from the frontend. 
- Provide runtime information about the bundled `yt-dlp` to the UI and keep progress/status persisted for polling and download. 

### Description
- Add a yt-dlp pipeline in `app/audio_pipeline.py` with helpers `normalize_output_format`, `normalize_bitrate`, `ytdlp_runtime_info`, `media_type_for_path`, and dedicated `_download_mp3` / `_download_mp4` flows that update job progress and call `ffmpeg` as needed. 
- Persist `output_format` and `bitrate` in the SQLite schema and `Audio` model and add a lightweight migration to `app/db.py`; change `create_audio_job` signature to accept `output_format` and `bitrate`. 
- Update the API to accept and validate `output_format` and `bitrate`, expose `/api/ytdlp/info`, and serve MP3/MP4 with correct media types in `app/main.py` and `backend/server.py`. 
- Add a frontend integration: `frontend/src/api.js` adds `getYtDlpInfo`, and `frontend/src/components/VideoDownloader.jsx` is replaced/rewritten with a full UI supporting output selection (MP3/MP4), bitrate selection, job submission, polling, local history, and direct download of the generated file. 
- Vendor/install changes: `backend/requirements.txt` updated to install `yt-dlp` from the project archive and add `setuptools` to avoid runtime import issues with `imageio-ffmpeg`; `imageio-ffmpeg` import is deferred in runtime to work around packaging environments. 

### Testing
- Ran the test suite with `pytest -q`, which passed (`9 passed`).
- Performed bytecode checks with `python -m py_compile` on `app/audio_pipeline.py`, `app/db.py`, `app/main.py`, `backend/server.py`, and `backend/downloader.py`, which succeeded. 
- Performed a runtime check of `audio_pipeline.ytdlp_runtime_info()` which returned the installed `yt-dlp` version and supported formats (successful). 
- Attempted to build the frontend (`npm ci` / `npm run build`) but this was blocked in the environment: `npm ci` failed with a registry `403 Forbidden` for `hls.js` and the earlier `npm run build` reported missing `cross-env`, so the production frontend build was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21ca7e90748333b4a0ac5d08848344)