### PR TITLE
Fix yt-dlp API base, add diagnostics and surface API error details

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-VITE_API_BASE=https://TON-BACKEND-RENDER.onrender.com
+VITE_API_BASE=https://spotifree-a0fz.onrender.com

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const CSP =
-  "default-src 'self'; img-src 'self' data: https:; media-src 'self' https: blob:; script-src 'self' 'unsafe-inline' https:; frame-src https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://api.jamendo.com https://*.audius.co https://audius.co https://freemusicarchive.org https://*.youtube.com https://i.ytimg.com https://spotifree-backend.onrender.com;";
+  "default-src 'self'; img-src 'self' data: https:; media-src 'self' https: blob:; script-src 'self' 'unsafe-inline' https:; frame-src https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self' https://api.jamendo.com https://*.audius.co https://audius.co https://freemusicarchive.org https://*.youtube.com https://i.ytimg.com https://spotifree-a0fz.onrender.com;";
 
 const nextConfig = {
   async headers() {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,12 +1,46 @@
 const envApiBase = typeof import.meta !== "undefined" ? import.meta.env?.VITE_API_BASE : undefined;
 const runtimeBase = typeof window !== "undefined" ? window.location.origin : "";
-const DEFAULT_API_BASE = "https://spotifree-backend.onrender.com";
+const DEFAULT_API_BASE = "https://spotifree-a0fz.onrender.com";
 
 export const API_BASE =
   (envApiBase && envApiBase.trim()) ||
   (runtimeBase && runtimeBase.includes("localhost") ? runtimeBase : DEFAULT_API_BASE);
 
 const API_ROOT = API_BASE.replace(/\/+$/, "");
+const YTDLP_INFO_URL = `${API_ROOT}/api/ytdlp/info`;
+
+const readErrorBody = async (response) => {
+  const text = await response.text().catch(() => "");
+  if (!text) return {};
+
+  try {
+    return JSON.parse(text);
+  } catch (parseError) {
+    return { message: text };
+  }
+};
+
+const extractApiDetail = (error) =>
+  error?.detail?.error?.message ||
+  error?.detail?.message ||
+  error?.detail ||
+  error?.error?.message ||
+  error?.message;
+
+const buildApiErrorMessage = (fallback, error) => {
+  const detail = extractApiDetail(error);
+  return detail ? `${fallback} : ${detail}` : fallback;
+};
+
+const logYtDlpInfoRequest = (details = {}) => {
+  console.info("[yt-dlp info] Configuration API", {
+    VITE_API_BASE: envApiBase,
+    API_BASE,
+    API_ROOT,
+    url: YTDLP_INFO_URL,
+    ...details,
+  });
+};
 
 export async function createJob(payload) {
   const response = await fetch(`${API_ROOT}/api/jobs`, {
@@ -18,8 +52,8 @@ export async function createJob(payload) {
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
-    throw Object.assign(new Error("Échec de la création du job"), { response, error });
+    const error = await readErrorBody(response);
+    throw Object.assign(new Error(buildApiErrorMessage("Échec de la création du job", error)), { response, error });
   }
 
   return response.json();
@@ -28,18 +62,44 @@ export async function createJob(payload) {
 export async function getJob(jobId) {
   const response = await fetch(`${API_ROOT}/api/jobs/${jobId}`);
   if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
-    throw Object.assign(new Error("Échec de la récupération du job"), { response, error });
+    const error = await readErrorBody(response);
+    throw Object.assign(new Error(buildApiErrorMessage("Échec de la récupération du job", error)), { response, error });
   }
   return response.json();
 }
 
 
 export async function getYtDlpInfo() {
-  const response = await fetch(`${API_ROOT}/api/ytdlp/info`);
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
-    throw Object.assign(new Error("Impossible de récupérer les informations yt-dlp"), { response, error });
+  logYtDlpInfoRequest();
+  let response;
+
+  try {
+    response = await fetch(YTDLP_INFO_URL);
+  } catch (networkError) {
+    console.error("[yt-dlp info] Échec réseau ou CORS", {
+      API_BASE,
+      API_ROOT,
+      url: YTDLP_INFO_URL,
+      error: networkError,
+    });
+    throw networkError;
   }
+
+  console.info("[yt-dlp info] Réponse HTTP", {
+    url: YTDLP_INFO_URL,
+    status: response.status,
+    ok: response.ok,
+  });
+
+  if (!response.ok) {
+    const error = await readErrorBody(response);
+    console.error("[yt-dlp info] Réponse en erreur", {
+      url: YTDLP_INFO_URL,
+      status: response.status,
+      body: error,
+    });
+    throw Object.assign(new Error(buildApiErrorMessage("Impossible de récupérer les informations yt-dlp", error)), { response, error });
+  }
+
   return response.json();
 }

--- a/frontend/src/components/VideoDownloader.jsx
+++ b/frontend/src/components/VideoDownloader.jsx
@@ -20,13 +20,26 @@ const initialForm = {
   bitrate: 192,
 };
 
-const extractApiMessage = (error, fallback) =>
-  error?.error?.detail?.error?.message ||
-  error?.error?.detail ||
-  error?.error?.error?.message ||
-  error?.error?.message ||
-  error?.message ||
-  fallback;
+const formatApiDetail = (detail) => {
+  if (!detail) return "";
+  if (typeof detail === "string") return detail;
+  if (typeof detail === "object") {
+    return detail?.error?.message || detail?.message || JSON.stringify(detail);
+  }
+  return String(detail);
+};
+
+const extractApiMessage = (error, fallback) => {
+  const detail =
+    error?.error?.detail?.error?.message ||
+    error?.error?.detail?.message ||
+    error?.error?.detail ||
+    error?.error?.error?.message ||
+    error?.error?.message ||
+    error?.message;
+  const message = formatApiDetail(detail);
+  return message || fallback;
+};
 
 const VideoDownloader = () => {
   const [form, setForm] = useState(initialForm);


### PR DESCRIPTION
### Motivation
- Le frontend continuait de retomber sur un ancien backend quand `VITE_API_BASE` n’était pas injectée, entraînant l’affichage « Impossible de récupérer les informations yt-dlp ». 
- Il fallait pouvoir tracer précisément quelle URL était appelée et afficher le détail renvoyé par l’API pour diagnostiquer les erreurs réseau/CORS ou réponses d’erreur du backend.

### Description
- Défini `DEFAULT_API_BASE` sur `https://spotifree-a0fz.onrender.com` et ajouté la variable `YTDLP_INFO_URL` pour construire l’URL exacte utilisée par `getYtDlpInfo()` (`frontend/src/api.js`).
- Ajouté des logs détaillés dans `getYtDlpInfo()` affichant `VITE_API_BASE`, `API_BASE`, `API_ROOT`, l’URL appelée, le statut HTTP et le corps d’erreur retourné, ainsi qu’un catch réseau pour distinguer échec réseau/CORS (`frontend/src/api.js`).
- Amélioré la lecture des corps d’erreur pour supporter JSON ou texte brut et construit des messages d’erreur plus informatifs (`frontend/src/api.js`).
- Modifié le composant `VideoDownloader` pour mieux formater et afficher les détails d’erreur retournés par l’API (`frontend/src/components/VideoDownloader.jsx`).
- Mis à jour `frontend/.env` pour définir `VITE_API_BASE=https://spotifree-a0fz.onrender.com` et corrigé la directive `connect-src` dans `frontend/next.config.js` pour autoriser le nouvel hôte backend afin d’éviter des blocages CSP côté navigateur.

### Testing
- `git diff --check` — ok (pas d’erreurs de style détectées). 
- `node --check --input-type=module < frontend/src/api.js` — ok (fichier `api.js` vérifié sans erreur syntaxique). 
- `node --check --input-type=module < frontend/src/components/VideoDownloader.jsx` — non applicable car `node --check` ne parse pas JSX et signale une erreur de syntaxe due au JSX. 
- `npm run build` — non exécuté avec succès dans cet environnement car `cross-env` absent (`cross-env: not found`). 
- `npm ci` — échec d’installation des dépendances à cause d’un `403 Forbidden` sur le registre pour une dépendance (`hls.js`) dans l’environnement d’exécution. 
- `curl` et `OPTIONS` sur `https://spotifree-a0fz.onrender.com/api/ytdlp/info` — vérifications réseau/CORS bloquées par le proxy de l’environnement (`CONNECT tunnel failed, response 403`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21d4c66db883338072a5f7008dd573)