### PR TITLE
Fix setuptools runtime for imageio-ffmpeg

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,4 +8,5 @@ pydantic==1.10.18
 python-multipart==0.0.9
 slowapi==0.1.8
 tenacity==8.2.3
-setuptools>=70
+# imageio-ffmpeg 0.4.9 imports pkg_resources at runtime; keep setuptools in a range that still ships it.
+setuptools>=70,<81


### PR DESCRIPTION
### Motivation
- Ensure `pkg_resources` (provided by `setuptools`) is available at runtime because `imageio-ffmpeg==0.4.9` imports it during job processing, so pin `setuptools` to a range that still ships `pkg_resources` by updating `backend/requirements.txt`; after merge, redeploy the Render backend without cache if possible.

### Description
- Update `backend/requirements.txt` by replacing `setuptools>=70` with a commented rationale and `setuptools>=70,<81`, keeping `yt-dlp` unchanged and documenting why the tighter constraint is required.

### Testing
- Parsed all active lines of `backend/requirements.txt` with `packaging.requirements.Requirement` (success), inspected the local `imageio_ffmpeg` package to confirm it references `pkg_resources` in `_utils.py` (success), and attempted a full `pip install -r backend/requirements.txt` in an isolated venv which was blocked by the environment proxy so the end-to-end install could not complete here (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21d7d0d7448333bf9ab231afd21379)